### PR TITLE
Quick fix for initialization failure

### DIFF
--- a/projects/button/src/lib/share-button.html
+++ b/projects/button/src/lib/share-button.html
@@ -19,11 +19,11 @@
 
     <div class="sb-content">
 
-      <div *ngIf="showIcon && ref.shareButton" class="sb-icon">
+      <div *ngIf="showIcon && ref?.shareButton" class="sb-icon">
         <fa-icon [icon]="icon || ref.shareButton.icon" [fixedWidth]="true"></fa-icon>
       </div>
 
-      <div *ngIf="showText && ref.shareButton" class="sb-text">
+      <div *ngIf="showText && ref?.shareButton" class="sb-text">
         {{ text || ref.shareButton.text }}
       </div>
 

--- a/projects/button/src/lib/share-button.ts
+++ b/projects/button/src/lib/share-button.ts
@@ -1,4 +1,14 @@
-import { Component, Input, Output, ViewChild, HostBinding, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  ViewChild,
+  HostBinding,
+  AfterViewInit,
+  EventEmitter,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef
+} from '@angular/core';
 import { ShareService, ShareDirective } from '@ngx-share/core';
 
 @Component({
@@ -7,7 +17,7 @@ import { ShareService, ShareDirective } from '@ngx-share/core';
   styleUrls: ['./share-button.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ShareButton {
+export class ShareButton implements AfterViewInit {
 
   /** The sharing link */
   url: string;
@@ -81,7 +91,12 @@ export class ShareButton {
 
   @ViewChild(ShareDirective) ref: ShareDirective;
 
-  constructor(private _share: ShareService) {
+  constructor(private _cd: ChangeDetectorRef,
+              private _share: ShareService) {
+  }
+
+  ngAfterViewInit() {
+    this._cd.detectChanges();
   }
 
   onCount(count: number) {

--- a/projects/core/src/lib/share-button.directive.ts
+++ b/projects/core/src/lib/share-button.directive.ts
@@ -7,6 +7,7 @@ import {
   Inject,
   OnChanges,
   OnDestroy,
+  OnInit,
   SimpleChanges,
   SimpleChange,
   EventEmitter,
@@ -28,7 +29,7 @@ import { ShareButtonBase } from './buttons';
 @Directive({
   selector: '[shareButton], [share-button]'
 })
-export class ShareDirective implements OnChanges, OnDestroy {
+export class ShareDirective implements OnChanges, OnDestroy, OnInit {
 
   /** A ref to button class - used to remove previous class when the button type is changed */
   private _buttonClass: string;
@@ -112,15 +113,15 @@ export class ShareDirective implements OnChanges, OnDestroy {
     );
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  init(changes?: SimpleChanges) {
     // Avoid SSR error
     if (this._platform.isBrowser) {
 
-      if (this._shareButtonChanged(changes['shareButtonName'])) {
+      if (!changes || this._shareButtonChanged(changes['shareButtonName'])) {
         this._createShareButton();
       }
 
-      if (this._urlChanged(changes['url'])) {
+      if (!changes || this._urlChanged(changes['url'])) {
         this.url = getValidUrl(
           this.autoSetMeta
             ? this.url || this._getMetaTagContent('og:url')
@@ -135,8 +136,16 @@ export class ShareDirective implements OnChanges, OnDestroy {
     }
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    this.init(changes);
+  }
+
   ngOnDestroy() {
     this._shareWindowClosed.unsubscribe();
+  }
+
+  ngOnInit() {
+    this.init();
   }
 
   private _createShareButton() {


### PR DESCRIPTION
In my project this fixes the issue of the button component immediately failing with an exception due to `ref` being initially undefined.

Ideally we would have strict null checks and Angular's new [strict mode](https://angular.io/guide/template-typecheck#strict-mode), but this at least fixes the immediate blocker.