### PR TITLE
fix(share-button): Skip empty params in shareUrl serialization

### DIFF
--- a/projects/ngx-sharebuttons/src/lib/share-button.directive.ts
+++ b/projects/ngx-sharebuttons/src/lib/share-button.directive.ts
@@ -315,6 +315,7 @@ export class ShareDirective implements OnInit, OnChanges, OnDestroy {
       }
       return '';
     })
+    .filter(urlParam => urlParam !== '')
     .join('&');
   }
 }


### PR DESCRIPTION
Empty params produced invalid URLs by adding an unnecessary `&` in the URL

fixes #478