### PR TITLE
Adds missing api to ngx-sharebuttons-demo

### DIFF
--- a/projects/ngx-sharebuttons-demo/src/assets/data/directive-api.json
+++ b/projects/ngx-sharebuttons-demo/src/assets/data/directive-api.json
@@ -30,6 +30,11 @@
     "type": "input"
   },
   {
+    "name": "autoSetMeta",
+    "description": "Auto set meta tags inputs from the SEO meta tags, default: true",
+    "type": "input"
+  },
+  {
     "name": "opened",
     "description": "Stream that emits when share dialog has opened",
     "type": "output"


### PR DESCRIPTION
**What is the PR for?**

- Adds missing api in share-button-directive demo docs.
![image](https://user-images.githubusercontent.com/118078892/210211538-42f162d7-f64b-4add-9e2a-51faac6524a6.png)
-  Reference : - [ Available Inputs / Outputs (wiki/Share Button Directive) ](https://github.com/MurhafSousli/ngx-sharebuttons/wiki/Share-Button-Directive#available-inputs--outputs)


