### PR TITLE
fix(#662): linkedin share button, to be able to share button description as ?text=

### DIFF
--- a/projects/ngx-sharebuttons/src/lib/share.defaults.ts
+++ b/projects/ngx-sharebuttons/src/lib/share.defaults.ts
@@ -50,7 +50,7 @@ export const SHARE_BUTTONS: IShareButtons = {
     params: {
       url: 'url',
       title: 'title',
-      description: 'summary'
+      description: 'text'
     }
   },
   pinterest: {


### PR DESCRIPTION
Fix to the https://github.com/MurhafSousli/ngx-sharebuttons/issues/662